### PR TITLE
Fix comment spacing in device management route

### DIFF
--- a/backend/app/routes/device_management.py
+++ b/backend/app/routes/device_management.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from app.database import get_db
-from app.models import Device as DeviceModel #used to import the SQLAlchemy model for devices
+from app.models import Device as DeviceModel  # Used to import the SQLAlchemy model for devices
 import secrets
 
 # Create a router for device management


### PR DESCRIPTION
## Summary
- correct inline comment spacing for SQLAlchemy device import

## Testing
- `python -m compileall backend/app/routes/device_management.py`

------
https://chatgpt.com/codex/tasks/task_e_688384af79888323912bb3377a5ff55b